### PR TITLE
support multi-platform image for linux/arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,13 @@ jobs:
    steps:
     - name: Check Out prometheus-dyson-exporter Repo 
       uses: actions/checkout@v4.2.2
-      
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v3.3.0
       with:
@@ -42,6 +48,7 @@ jobs:
       uses: docker/build-push-action@v6.9.0
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         file: ./Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build_and_push:


### PR DESCRIPTION
Supported linux/arm64, multi-platform image.
I want to run your awesome exporter on Raspberry Pi 5 that is linux/arm64/v8.

If you don't need this PR, forgive me.

---

I have already confirmed successful build and upload.
* test commit
  * this PR changed 2ea59427a9515b7edf4f0f8820c3ad68fc33de5d
  * for testing, changed configure temporary https://github.com/watahari/prometheus-dyson-exporter/commit/0a1295c1ff4b3e32711fb147f1826aea20650c25
* then, GitHub acition works as expected
  * https://github.com/watahari/prometheus-dyson-exporter/actions/runs/13117647859/job/36595767669
* Multi-platform arm64 and amd64 images have been uploaded to docker hub.
  * https://hub.docker.com/repository/docker/watahari/prometheus-dyson-exporter/tags/test/sha256:d818a3e297e411afb45adc1a43f6d2c29b96d319d565f0360b2e934b35d468fb

---

It worked on my Raspberry Pi 5.

before
```
$ uname -a
Linux XXXXXXX 6.6.62+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.6.62-1+rpt1 (2024-11-25) aarch64 GNU/Linux
$ sudo docker compose up -d
...
 ! prometheus-dyson-exporter The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                            0.0s
```

after
```
$ uname -a
Linux XXXXXXX 6.6.62+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.6.62-1+rpt1 (2024-11-25) aarch64 GNU/Linux
$ tail -16 docker-compose.yaml
  prometheus-dyson-exporter:
    # image: zkhcohen/prometheus-dyson-exporter:latest
    #   is not support linux/amd64
    image: watahari/prometheus-dyson-exporter:test
    container_name: prometheus-dyson-exporter
    ports:
      - "9672:9672"
    environment:
      - EXPORTER_PORT
      - EXPORTER_LOG_LEVEL
      - CONFIG_PATH
      - DYSON_SERIAL
      - DYSON_CREDENTIAL
      - DYSON_DEVICE_TYPE
      - DYSON_IP
    restart: always
$ sudo docker compose up -d
[+] Running 9/9
 ✔ prometheus-dyson-exporter Pulled                                                                                                                                                                   30.9s
   ✔ 7ce705000c39 Pull complete                                                                                                                                                                        8.6s
   ✔ 4bed81d0786a Pull complete                                                                                                                                                                        8.9s
   ✔ 7b864cf4b9bc Pull complete                                                                                                                                                                        9.9s
   ✔ 0635c9df184f Pull complete                                                                                                                                                                       26.5s
   ✔ ed9899145c23 Pull complete                                                                                                                                                                       26.6s
   ✔ 8ee48a17605b Pull complete                                                                                                                                                                       26.7s
   ✔ 406e0d65bdc5 Pull complete                                                                                                                                                                       26.8s
   ✔ 80b39eef079d Pull complete                                                                                                                                                                       27.6s
[+] Running 9/9
...
 ✔ Container prometheus-dyson-exporter                  Started                                                                                                                                        5.7s
....
```
```
$ curl "http://localhost:9672/metrics"
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 280.0
python_gc_objects_collected_total{generation="1"} 84.0
python_gc_objects_collected_total{generation="2"} 0.0
....
```
